### PR TITLE
Add items field to ListComponent interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@efstajas/tela",
-  "version": "0.4.4",
+  "version": "4.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@efstajas/tela",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "A framework for building Intercom Canvas Kit applications.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/intercom.types.ts
+++ b/src/intercom.types.ts
@@ -37,7 +37,8 @@ export type Component =
 
 export interface ListComponent {
   type: 'list',
-  disabled?: boolean
+  disabled?: boolean,
+  items: ListComponentItem[]
 } 
 
 export interface ListComponentItem {


### PR DESCRIPTION
Items is a required field in [List](https://developers.intercom.com/canvas-kit-reference/reference/list), but is not present in the type declaration, so a type error is thrown when a user attempts to create a list with items in it.

This PR addresses the issue by declaring the `items` field as an array of objects matching the existing ListComponentItem interface in accordance with the Canvas Kit spec.